### PR TITLE
docs/test: add circuit breaker API docs and test updates

### DIFF
--- a/crates/fusiongraph-core/src/csr/builder.rs
+++ b/crates/fusiongraph-core/src/csr/builder.rs
@@ -451,12 +451,7 @@ mod tests {
             let node = NodeId::new(node_id);
             if let Some((shard_idx, offset)) = graph.global_to_shard(node) {
                 let recovered = graph.shard_to_global(shard_idx, offset);
-                assert_eq!(
-                    recovered,
-                    Some(node),
-                    "Roundtrip failed for node {}",
-                    node_id
-                );
+                assert_eq!(recovered, Some(node), "Roundtrip failed for node {node_id}");
             }
         }
     }
@@ -478,8 +473,7 @@ mod tests {
             let result = graph.global_to_shard(node);
             assert!(
                 result.is_some(),
-                "global_to_shard failed for node {}",
-                node_id
+                "global_to_shard failed for node {node_id}"
             );
 
             let (shard_idx, offset) = result.unwrap();
@@ -487,10 +481,7 @@ mod tests {
             assert_eq!(
                 recovered,
                 Some(node),
-                "Roundtrip failed for node {} (shard={}, offset={})",
-                node_id,
-                shard_idx,
-                offset
+                "Roundtrip failed for node {node_id} (shard={shard_idx}, offset={offset})"
             );
         }
     }
@@ -556,8 +547,7 @@ mod tests {
                 // Range should start where previous ended
                 assert_eq!(
                     range.start, covered_nodes,
-                    "Gap in shard coverage at shard {}",
-                    shard_idx
+                    "Gap in shard coverage at shard {shard_idx}"
                 );
 
                 covered_nodes = range.end;

--- a/crates/fusiongraph-datafusion/src/exec/graph_traversal.rs
+++ b/crates/fusiongraph-datafusion/src/exec/graph_traversal.rs
@@ -330,9 +330,8 @@ mod tests {
         let ctx = SessionContext::new();
         let task_ctx = ctx.task_ctx();
 
-        let err = match exec.execute(0, task_ctx) {
-            Ok(_) => panic!("DFS traversal should not be accepted before implementation"),
-            Err(err) => err,
+        let Err(err) = exec.execute(0, task_ctx) else {
+            panic!("DFS traversal should not be accepted before implementation");
         };
         assert!(err.to_string().contains("only supports BFS traversal"));
     }
@@ -352,9 +351,8 @@ mod tests {
         let ctx = SessionContext::new();
         let task_ctx = ctx.task_ctx();
 
-        let err = match exec.execute(0, task_ctx) {
-            Ok(_) => panic!("incoming traversal should not be accepted before implementation"),
-            Err(err) => err,
+        let Err(err) = exec.execute(0, task_ctx) else {
+            panic!("incoming traversal should not be accepted before implementation");
         };
         assert!(err.to_string().contains("only supports outgoing traversal"));
     }
@@ -420,7 +418,7 @@ mod tests {
 
         let exec = GraphTraversalExec::new(graph, spec);
         // Verify DisplayAs is implemented - use Debug format for testing
-        let debug_str = format!("{:?}", exec);
+        let debug_str = format!("{exec:?}");
         assert!(debug_str.contains("GraphTraversalExec"));
     }
 }

--- a/crates/fusiongraph-datafusion/src/provider.rs
+++ b/crates/fusiongraph-datafusion/src/provider.rs
@@ -256,10 +256,10 @@ properties = ["since"]
         ontology
     }
 
-    fn assert_id_fields(schema: &Schema, expected: DataType) {
+    fn assert_id_fields(schema: &Schema, expected: &DataType) {
         for field_name in ["node_id", "source_id", "target_id"] {
             if let Ok(field) = schema.field_with_name(field_name) {
-                assert_eq!(field.data_type(), &expected);
+                assert_eq!(field.data_type(), expected);
             }
         }
     }
@@ -325,8 +325,8 @@ properties = ["since"]
             .edge_schema("FOLLOWS")
             .expect("FOLLOWS schema should exist");
 
-        assert_id_fields(&node_schema, DataType::UInt64);
-        assert_id_fields(&edge_schema, DataType::UInt64);
+        assert_id_fields(&node_schema, &DataType::UInt64);
+        assert_id_fields(&edge_schema, &DataType::UInt64);
     }
 
     #[test]
@@ -341,8 +341,8 @@ properties = ["since"]
             .edge_schema("FOLLOWS")
             .expect("FOLLOWS schema should exist");
 
-        assert_id_fields(&node_schema, DataType::FixedSizeBinary(16));
-        assert_id_fields(&edge_schema, DataType::FixedSizeBinary(16));
+        assert_id_fields(&node_schema, &DataType::FixedSizeBinary(16));
+        assert_id_fields(&edge_schema, &DataType::FixedSizeBinary(16));
     }
 
     #[test]
@@ -398,9 +398,8 @@ properties = ["since"]
         let ctx = datafusion::prelude::SessionContext::new();
         let state = ctx.state();
 
-        let err = match provider.create_traversal_plan(&state, spec, &[]).await {
-            Ok(_) => panic!("traversal plan creation should be gated until execution exists"),
-            Err(err) => err,
+        let Err(err) = provider.create_traversal_plan(&state, spec, &[]).await else {
+            panic!("traversal plan creation should be gated until execution exists");
         };
 
         assert!(matches!(err, DataFusionError::NotImplemented(_)));

--- a/docs/FusionGraph_API_Reference.md
+++ b/docs/FusionGraph_API_Reference.md
@@ -774,6 +774,94 @@ pub enum GraphError {
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+
+    #[error("Circuit breaker open, failing fast")]
+    CircuitOpen,
+
+    #[error("Internal error: {0}")]
+    Internal(String),
+}
+```
+
+### 8.1 Circuit Breaker
+
+Thread-safe circuit breaker for protecting against external dependency failures.
+
+```rust
+use std::time::Duration;
+
+/// Circuit breaker states.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CircuitState {
+    /// Normal operation - requests flow through.
+    Closed,
+    /// Dependency failing - requests fail fast.
+    Open,
+    /// Testing recovery - limited requests allowed.
+    HalfOpen,
+}
+
+/// Configuration for circuit breaker behavior.
+#[derive(Debug, Clone)]
+pub struct CircuitBreakerConfig {
+    /// Failures before opening circuit (default: 5).
+    pub failure_threshold: u64,
+    /// Time before attempting recovery (default: 30s).
+    pub reset_timeout: Duration,
+    /// Successes in half-open to close circuit (default: 2).
+    pub success_threshold: u64,
+}
+
+/// Thread-safe circuit breaker using atomic operations.
+#[derive(Debug)]
+pub struct CircuitBreaker { /* ... */ }
+
+impl CircuitBreaker {
+    /// Create with custom configuration.
+    pub fn new(config: CircuitBreakerConfig) -> Self;
+    
+    /// Create with default configuration.
+    pub fn with_defaults() -> Self;
+    
+    /// Get current circuit state.
+    pub fn state(&self) -> CircuitState;
+    
+    /// Check if request should proceed.
+    /// Returns `Err(GraphError::CircuitOpen)` if circuit is open.
+    pub fn check(&self) -> Result<(), GraphError>;
+    
+    /// Record successful operation (resets failure count in Closed,
+    /// may close circuit in HalfOpen).
+    pub fn record_success(&self);
+    
+    /// Record failed operation (may open circuit).
+    pub fn record_failure(&self);
+    
+    /// Force reset to Closed state.
+    pub fn reset(&self);
+    
+    /// Current failure count.
+    pub fn failure_count(&self) -> u64;
+}
+```
+
+**Usage:**
+
+```rust
+let cb = CircuitBreaker::with_defaults();
+
+// Guard external calls
+cb.check()?;  // Fails fast if open
+
+match iceberg_client.fetch_table(name).await {
+    Ok(table) => {
+        cb.record_success();
+        Ok(table)
+    }
+    Err(e) => {
+        cb.record_failure();
+        Err(e)
+    }
 }
 ```
 

--- a/docs/FusionGraph_API_Reference.md
+++ b/docs/FusionGraph_API_Reference.md
@@ -775,20 +775,22 @@ pub enum GraphError {
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 
-    #[error("Circuit breaker open, failing fast")]
+    #[error("FG-SYS-E001: Circuit breaker open, failing fast")]
     CircuitOpen,
 
-    #[error("Internal error: {0}")]
-    Internal(String),
+    #[error("FG-SYS-E002: Internal error: {message}")]
+    Internal { message: String },
 }
 ```
 
 ### 8.1 Circuit Breaker
 
 Thread-safe circuit breaker for protecting against external dependency failures.
+Implemented in `fusiongraph_core::circuit_breaker`.
 
 ```rust
 use std::time::Duration;
+use fusiongraph_core::error::GraphError;
 
 /// Circuit breaker states.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/docs/FusionGraph_Error_Taxonomy.md
+++ b/docs/FusionGraph_Error_Taxonomy.md
@@ -425,9 +425,39 @@ CsrCorruption { shard_id: u32, expected: u64, actual: u64 }
 
 ---
 
-## 14. Error Handling Patterns
+## 14. System Errors (SYS)
 
-### 14.1 Rust Error Propagation
+### FG-SYS-E001: Circuit Breaker Open
+
+**Cause:** External dependency failure threshold exceeded  
+**Detection:** Circuit breaker state check  
+**User Message:** `Circuit breaker open, failing fast`  
+**Recovery:** Wait for reset timeout, then retry. If persistent, investigate underlying dependency.
+
+```rust
+#[error("FG-SYS-E001: Circuit breaker open, failing fast")]
+CircuitOpen
+```
+
+**Retryable:** Yes (after reset_timeout elapses)
+
+### FG-SYS-E002: Internal Error
+
+**Cause:** Unexpected internal state or bug  
+**Detection:** Assertion failure or unexpected condition  
+**User Message:** `Internal error: {message}`  
+**Recovery:** Report bug with context. May require service restart.
+
+```rust
+#[error("FG-SYS-E002: Internal error: {message}")]
+Internal { message: String }
+```
+
+---
+
+## 15. Error Handling Patterns
+
+### 15.1 Rust Error Propagation
 
 ```rust
 use thiserror::Error;
@@ -486,7 +516,7 @@ impl GraphError {
 }
 ```
 
-### 14.2 Graceful Degradation
+### 15.2 Graceful Degradation
 
 ```rust
 impl CsrGraph {
@@ -513,69 +543,78 @@ impl CsrGraph {
 }
 ```
 
-### 14.3 Circuit Breaker
+### 15.3 Circuit Breaker
+
+The circuit breaker pattern prevents cascading failures when external dependencies become unavailable.
 
 ```rust
+use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
+use std::time::Duration;
+
+/// Circuit breaker states.
+pub enum CircuitState {
+    Closed = 0,   // Normal operation
+    Open = 1,     // Failing fast
+    HalfOpen = 2, // Testing recovery
+}
+
+/// Configuration for circuit breaker behavior.
+pub struct CircuitBreakerConfig {
+    pub failure_threshold: u64,    // Default: 5
+    pub reset_timeout: Duration,   // Default: 30 seconds
+    pub success_threshold: u64,    // Default: 2
+}
+
+/// Thread-safe circuit breaker using atomic operations.
 pub struct CircuitBreaker {
-    failure_count: AtomicU32,
-    last_failure: AtomicU64,
-    state: AtomicU8, // 0=Closed, 1=Open, 2=HalfOpen
+    config: CircuitBreakerConfig,
+    state: AtomicU8,
+    failure_count: AtomicU64,
+    success_count: AtomicU64,
+    last_failure_time: AtomicU64,
 }
 
 impl CircuitBreaker {
-    const FAILURE_THRESHOLD: u32 = 5;
-    const RESET_TIMEOUT_MS: u64 = 30_000;
+    /// Check if request should proceed.
+    /// Returns Ok(()) or Err(GraphError::CircuitOpen).
+    pub fn check(&self) -> Result<()>;
     
-    pub fn call<T, E>(&self, f: impl FnOnce() -> Result<T, E>) -> Result<T, GraphError> {
-        match self.state.load(Ordering::Acquire) {
-            0 => { // Closed - normal operation
-                match f() {
-                    Ok(v) => {
-                        self.failure_count.store(0, Ordering::Release);
-                        Ok(v)
-                    }
-                    Err(_) => {
-                        if self.failure_count.fetch_add(1, Ordering::AcqRel) >= Self::FAILURE_THRESHOLD {
-                            self.state.store(1, Ordering::Release);
-                            self.last_failure.store(now_ms(), Ordering::Release);
-                        }
-                        Err(GraphError::CircuitOpen)
-                    }
-                }
-            }
-            1 => { // Open - fail fast
-                if now_ms() - self.last_failure.load(Ordering::Acquire) > Self::RESET_TIMEOUT_MS {
-                    self.state.store(2, Ordering::Release);
-                    self.call(f) // Try half-open
-                } else {
-                    Err(GraphError::CircuitOpen)
-                }
-            }
-            2 => { // Half-open - test
-                match f() {
-                    Ok(v) => {
-                        self.state.store(0, Ordering::Release);
-                        self.failure_count.store(0, Ordering::Release);
-                        Ok(v)
-                    }
-                    Err(_) => {
-                        self.state.store(1, Ordering::Release);
-                        self.last_failure.store(now_ms(), Ordering::Release);
-                        Err(GraphError::CircuitOpen)
-                    }
-                }
-            }
-            _ => unreachable!()
-        }
+    /// Record a successful operation (resets failure count).
+    pub fn record_success(&self);
+    
+    /// Record a failed operation (may trip circuit).
+    pub fn record_failure(&self);
+    
+    /// Reset circuit to closed state.
+    pub fn reset(&self);
+}
+```
+
+**Usage Pattern:**
+
+```rust
+let cb = CircuitBreaker::with_defaults();
+
+// Before calling external dependency
+cb.check()?;
+
+match external_call() {
+    Ok(result) => {
+        cb.record_success();
+        Ok(result)
+    }
+    Err(e) => {
+        cb.record_failure();
+        Err(e)
     }
 }
 ```
 
 ---
 
-## 15. Logging & Alerting
+## 16. Logging & Alerting
 
-### 15.1 Structured Logging
+### 16.1 Structured Logging
 
 ```rust
 use tracing::{error, warn, info, instrument};
@@ -592,7 +631,7 @@ pub fn traverse(graph: &CsrGraph, start: NodeId, max_depth: u32) -> Result<Trave
 }
 ```
 
-### 15.2 Alert Rules
+### 16.2 Alert Rules
 
 ```yaml
 # alertmanager/rules/fusiongraph.yml
@@ -625,9 +664,9 @@ groups:
 
 ---
 
-## 16. Recovery Procedures
+## 17. Recovery Procedures
 
-### 16.1 CSR Corruption Recovery
+### 17.1 CSR Corruption Recovery
 
 ```bash
 #!/bin/bash
@@ -655,7 +694,7 @@ fusiongraph-cli verify --checksums
 fusiongraph-cli resume
 ```
 
-### 16.2 Delta Layer Recovery
+### 17.2 Delta Layer Recovery
 
 ```bash
 #!/bin/bash
@@ -675,7 +714,7 @@ fi
 
 ---
 
-## 17. Error Metrics
+## 18. Error Metrics
 
 ```rust
 use prometheus::{IntCounterVec, register_int_counter_vec};

--- a/docs/FusionGraph_Error_Taxonomy.md
+++ b/docs/FusionGraph_Error_Taxonomy.md
@@ -550,6 +550,7 @@ The circuit breaker pattern prevents cascading failures when external dependenci
 ```rust
 use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::time::Duration;
+use fusiongraph_core::GraphError;
 
 /// Circuit breaker states.
 pub enum CircuitState {
@@ -577,7 +578,7 @@ pub struct CircuitBreaker {
 impl CircuitBreaker {
     /// Check if request should proceed.
     /// Returns Ok(()) or Err(GraphError::CircuitOpen).
-    pub fn check(&self) -> Result<()>;
+    pub fn check(&self) -> Result<(), GraphError>;
     
     /// Record a successful operation (resets failure count).
     pub fn record_success(&self);

--- a/docs/FusionGraph_Testing_Strategy.md
+++ b/docs/FusionGraph_Testing_Strategy.md
@@ -52,6 +52,8 @@ Test individual functions and structs in isolation.
 | `traversal::dijkstra` | Priority queue, weight handling |
 | `simd::*` | SIMD intrinsics (platform-specific) |
 | `ffi::arrow` | Arrow import/export correctness |
+| `circuit_breaker` | State transitions, failure thresholds, reset timing |
+| `error` | Error codes, severity, retryability |
 
 ### 3.3 Test Patterns
 


### PR DESCRIPTION
## Summary

Updates documentation to reflect the implemented circuit breaker API and system error taxonomy, and includes the related DataFusion/core test cleanup currently carried by this branch.

## Changes

### Error taxonomy and API reference
- Added System Errors (SYS) documentation for `FG-SYS-E001` and `FG-SYS-E002`.
- Updated the API reference `GraphError` snippet to match `crates/fusiongraph-core/src/error.rs`, including `FG-SYS-*` prefixes and `Internal { message: String }`.
- Documented the circuit breaker API as implemented in `fusiongraph_core::circuit_breaker`.
- Updated the error taxonomy circuit breaker example to use explicit `Result<(), GraphError>`.

### Test and code cleanup
- Merged current `main` so the documented circuit breaker implementation and tests are present in this PR context.
- Kept the DataFusion CSR builder test scope explicit as graph metadata coverage.
- Cleaned clippy warnings in core/datafusion tests after the current-main merge.

## QA evidence

- `cargo fmt --check` passed.
- `git diff --check` passed.
- `CARGO_TARGET_DIR=/tmp/fusiongraph-qa/target cargo test -p fusiongraph-core -p fusiongraph-datafusion` passed: 53 core tests and 29 datafusion tests.
- `CARGO_TARGET_DIR=/tmp/fusiongraph-qa/target cargo clippy -p fusiongraph-core -p fusiongraph-datafusion --all-targets -- -D warnings` passed.

## Next QA requirements

- Verify docs snippets against live Rust types before requesting review.
- Keep PR title/body aligned with any code or test files included in the branch.
- Run `cargo fmt --check`, `git diff --check`, focused package tests, and focused clippy with `-D warnings` before moving to review.
